### PR TITLE
Fix Qt resource path in CMake configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ set(PROSHOTTR_SOURCES
 
 qt_add_executable(ProShottr WIN32 MACOSX_BUNDLE
     ${PROSHOTTR_SOURCES}
-    resources/proshottr.qrc
+    ${CMAKE_SOURCE_DIR}/resources/proshottr.qrc
 )
 
 qt_add_qml_module(ProShottr


### PR DESCRIPTION
## Summary
- update the ProShottr executable target to reference the Qt resource file using an absolute source directory path so CMake can locate it during configuration

## Testing
- cmake -S . -B build *(fails: Qt6 development packages are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6530faebc8329a0bad32d98ab10aa